### PR TITLE
quick hotfix for model select bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ ollama-ext/
 ## Prerequisites
 
 - [Ollama](https://ollama.ai) installed and running locally
-- A model installed (e.g., `llama3.2`, `llama2`, `mistral`)
+- At least one model installed:
+  ```bash
+  ollama pull llama3.2
+  # Or any other model: mistral, qwen2.5, deepseek-r1, etc.
+  ```
 
 ## Quick Install
 
@@ -52,12 +56,17 @@ ollama-ext/
 **Windows:** `[System.Environment]::SetEnvironmentVariable('OLLAMA_ORIGINS', '*', 'User')`  
 **Mac/Linux:** `echo 'export OLLAMA_ORIGINS="*"' >> ~/.bashrc && source ~/.bashrc`
 
-### 2. Start Ollama
+### 2. Install a model (if you haven't already)
+```bash
+ollama pull llama3.2
+```
+
+### 3. Start Ollama
 ```bash
 ollama serve
 ```
 
-### 3. Load extension
+### 4. Load extension
 1. Chrome → `chrome://extensions/` → Enable "Developer mode"
 2. Click "Load unpacked" → Select `ollama-ext` folder
 

--- a/src/background.js
+++ b/src/background.js
@@ -2,10 +2,9 @@
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Ollama Web Summarizer installed');
   
-  // Set default settings
+  // Set default URL only - model will be auto-selected from available models
   chrome.storage.local.set({
-    ollamaUrl: 'http://localhost:11434',
-    model: 'llama3.2:latest'
+    ollamaUrl: 'http://localhost:11434'
   });
   
   // Create context menu for selected text
@@ -89,7 +88,7 @@ async function callOllamaAPI(prompt, context = '', onChunk) {
     if (response.status === 403) {
       errorMsg += '\n\n⚠️ CORS Error: Set OLLAMA_ORIGINS="*" environment variable and restart Ollama.';
     } else if (response.status === 404 && errorText.includes('not found')) {
-      errorMsg += `\n\n⚠️ Model not found! Install it with: ollama pull ${model}\nOr select a different model from the dropdown.`;
+      errorMsg += `\n\n⚠️ Model "${model}" not found!\n\nOptions:\n1. Select a different model from the dropdown (shows your installed models)\n2. Install this model: ollama pull ${model}`;
     }
     
     throw new Error(errorMsg);

--- a/src/popup.html
+++ b/src/popup.html
@@ -17,11 +17,7 @@
         <div class="setting-group">
           <label for="modelSelect">Model:</label>
           <select id="modelSelect">
-            <option value="llama3.2:latest">llama3.2</option>
-            <option value="deepseek-r1:8b">deepseek-r1:8b</option>
-            <option value="qwen3:30b">qwen3:30b</option>
-            <option value="gpt-oss:20b">gpt-oss:20b</option>
-            <option value="llama4:scout">llama4:scout</option>
+            <option value="">Loading models...</option>
           </select>
         </div>
         <div class="setting-group">

--- a/src/popup.js
+++ b/src/popup.js
@@ -125,15 +125,21 @@ async function loadAvailableModels() {
           if (result.model && Array.from(modelSelect.options).some(opt => opt.value === result.model)) {
             modelSelect.value = result.model;
           } else if (modelSelect.options.length > 0) {
+            // Use first available model as default
             modelSelect.value = modelSelect.options[0].value;
             chrome.storage.local.set({ model: modelSelect.value });
           }
         });
+      } else {
+        // No models found
+        modelSelect.innerHTML = '<option value="">No models installed - run: ollama pull llama3.2</option>';
       }
+    } else {
+      modelSelect.innerHTML = '<option value="">Cannot connect to Ollama</option>';
     }
   } catch (error) {
     console.error('Failed to load models:', error);
-    // Keep default options if fetch fails
+    modelSelect.innerHTML = '<option value="">Cannot connect to Ollama - is it running?</option>';
   }
 }
 


### PR DESCRIPTION
Now installing models is clearly documented in three places:
1. Prerequisites section - Shows users they need at least one model before starting
2. Quick Install Step 2 - Explicitly tells them to run ollama pull llama3.2
3. Configuration section - Shows how to add multiple models with specific examples